### PR TITLE
fix: 默认关闭托盘图标，规避 Windows 下切换窗口时任务栏卡死数秒

### DIFF
--- a/weasel.custom.yaml
+++ b/weasel.custom.yaml
@@ -61,7 +61,7 @@ patch:
   style/label_font_point: 14 #★序号字号，小于等于候选字号
   style/hide_candidates_when_single: false      #★preedit_inline时，只有一个候选时隐藏候选框不绘制
   style/preedit_type: composition #隐藏候选窗(margin_x或margin_y为负数，负数即可)+ style/preedit_type: preview_all
-  style/display_tray_icon: true  #显示托盘图标
+  style/display_tray_icon: false  #托盘图标；请保持 false，为 true 时会与任务栏 UI 线程死锁，点任务栏切换窗口卡约 7 秒（rime/weasel#1909）
   style/label_format: "%s." #编号规则
   style/layout/align_type: bottom #★文字偏置，主要影响label和comment居上/居中/居下布置，尤其是label和comment字体比候选字小的时候，bottom/center/top, 
   style/layout/min_width: 0  #候选栏最小宽度


### PR DESCRIPTION
## 问题

在 Windows 上使用本方案时，**点击任务栏切换窗口会导致整个桌面冻结约 5–7 秒**。`Alt+Tab` 切换则不受影响。

## 根因

`weasel.custom.yaml` 中的 `style/display_tray_icon: true` 会触发小狼毫的一个跨进程死锁（上游 [rime/weasel#1909](https://github.com/rime/weasel/issues/1909)，目前仍 open）：

1. 点任务栏 → `explorer.exe` 的任务栏 UI 线程经 TSF 调进 `weasel.dll`，在命名管道上 **无超时** `ReadFile` 等待 WeaselServer 回应；
2. 同一时刻 WeaselServer 正在刷新托盘图标，`Shell_NotifyIcon` 内部以 `SendMessageTimeoutW`（超时**写死 7000ms**）向 `Shell_TrayWnd` 发消息；
3. 而那条任务栏线程停在 `WaitForSingleObject` 上，根本不抽取消息队列 —— 环闭合，只能等那个 7000ms 超时打破。

冻结期间 WeaselServer 的 CPU 增量为 0，说明它不是在计算而是被阻塞。这也解释了为何 Alt+Tab 不卡：不经过任务栏 UI 线程，死锁环接不起来。

## 为什么改成 false

**小狼毫发行版自带的 `weasel.yaml` 中该项默认值本来就是 `false`**（`weasel-0.17.4/data/weasel.yaml`）。本仓库沿用的 `true` 来自 rime/home wiki「小狼毫外觀設定」的示例配置。rime/weasel#1909 中明确点名该 wiki 示例「很大程度上增加了目前卡頓情況的發生機率」。

上游 issue 里给出的 A/B/A 对照实验（同一 explorer.exe 实例，只改这一个布尔值）：

| 阶段 | display_tray_icon | 时长 | 冻结次数 |
|---|---|---|---|
| A | `true` | ~15 min | 7 次，每次 5.9–6.1 s |
| B | **`false`** | 15 min | **0 次** |
| A' | `true` | 20 min | 3 次 |

`WeaselTrayIcon::Refresh()` 在该项为 false 时会提前返回、不调用 `Shell_NotifyIcon`，精准移除死锁环的一条边。

## 验证

- 环境：Windows 11 build 26200 / Weasel 0.17.4 / librime 1.13.1 / AMD Ryzen 7 5800H
- 改前：`explorer.exe` 反复产生 `AppHangTransient` 事件，点任务栏切窗口稳定复现数秒冻结
- 改后重新部署：不再复现

## 影响

仅去掉通知区的托盘图标，不影响任何输入功能。需要查看部署状态的用户可自行改回 `true`（注释里已说明代价）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)